### PR TITLE
Add support for custom URI prefix

### DIFF
--- a/src/M24SR.cpp
+++ b/src/M24SR.cpp
@@ -1603,6 +1603,11 @@ void M24SR::readTxt(char text_read[])
 
 bool M24SR::writeUri(const char *uri)
 {
+  return M24SR::writeUri("http://www.", uri);
+}
+
+bool M24SR::writeUri(const char *scheme, const char *uri)
+{
   bool success = false;
 
   //retrieve the NdefLib interface
@@ -1612,7 +1617,7 @@ bool M24SR::writeUri(const char *uri)
   if(tag->open_session()) {
     //create the NDef message and record
     NDefLib::Message msg;
-    NDefLib::RecordURI rUri(NDefLib::RecordURI::HTTP_WWW, uri);
+    NDefLib::RecordURI rUri(scheme, uri);
     msg.add_record(&rUri);
     //write the tag
     if(tag->write(msg)) {

--- a/src/M24SR.h
+++ b/src/M24SR.h
@@ -159,9 +159,14 @@ public:
 	void readTxt(char text_read[]);
 
 	/**
-	 * This function write a URI in the NFC flag
+	 * This function write a URI in the NFC flag (scheme: "http://www.")
 	 */
-	bool writeUri(const char *text);
+	bool writeUri(const char *uri);
+
+	/**
+	 * This function writes a URI in the NFC flag with a custom scheme
+	 */
+	bool writeUri(const char *scheme, const char *uri);
 
 	/**
 	 * This function read the URI in the NFC flag and return it


### PR DESCRIPTION
Up until now the `writeUri` method used an hard-coded prefix of `http://www.`

This merge-request adds a two argument `writeUri` method that takes both the prefix and the the uri.

For backward-compatibility the single argument method still works and has the same behavior.

**Note**: I couldn't check if this merge request was working because I don't know how to create an Arduino Library. I just hopped that by making the merge-request the change would be accepted more easily.